### PR TITLE
Add Poseidon instance exports to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,24 @@
     "@babel/preset-env": "^7.20.2",
     "circomlibjs": "^0.1.7",
     "prettier": "^2.8.7"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./poseidon1": "./poseidon1.js",
+    "./poseidon2": "./poseidon2.js",
+    "./poseidon3": "./poseidon3.js",
+    "./poseidon4": "./poseidon4.js",
+    "./poseidon5": "./poseidon5.js",
+    "./poseidon6": "./poseidon6.js",
+    "./poseidon7": "./poseidon7.js",
+    "./poseidon8": "./poseidon8.js",
+    "./poseidon9": "./poseidon9.js",
+    "./poseidon10": "./poseidon10.js",
+    "./poseidon11": "./poseidon11.js",
+    "./poseidon12": "./poseidon12.js",
+    "./poseidon13": "./poseidon13.js",
+    "./poseidon14": "./poseidon14.js",
+    "./poseidon15": "./poseidon15.js",
+    "./poseidon16": "./poseidon16.js"
   }
 }


### PR DESCRIPTION
This PR adds Poseidon instance exports to `package.json`. This fixes an issue where module requests for e.g. `poseidon-lite/poseidon1` aren't properly resolved on certain ESM standards-compliant runtimes. For instance, using [Deno](https://deno.com/) by running `deno run` on a file containing the following yields an error:

```typescript
import { poseidon1 } from "npm:poseidon-lite/poseidon1";

const hash = poseidon1([0n]);
```

Replacing `package.json` with the one here fixes this.